### PR TITLE
Made opt name and documentation clearer

### DIFF
--- a/spark-cloud.py
+++ b/spark-cloud.py
@@ -178,9 +178,11 @@ def parse_options():
         "-m", "--master-instance-type", default="m3.medium",
         help="Master instance type (default: %default)")
     parser.add_option(
-        "--spot-price", metavar="PRICE", type="float",
+        "--spot-price-max", metavar="PRICE", type="float",
         help="If specified, launch workers as spot instances with the given " +
-             "maximum price (in dollars)")
+             "maximum price (in dollars). The actual price paid will be the market price " +
+             "so potentially less than this value. If the market price exceeds this value " +
+             "your nodes will shut down and no more will spin up")
     parser.add_option(
         "--subnet-id", default=None,
         help="VPC subnet to launch instances in")
@@ -270,7 +272,7 @@ def create_autoscaling_group(autoscale, cluster_name, master_node, opts, slave_g
             instance_type=opts.instance_type,
             user_data="SPARK_MASTER=" + master_node.private_dns_name + "\n",
             instance_monitoring=True,
-            spot_price=opts.spot_price)
+            spot_price=opts.spot_price_max)
         autoscale.create_launch_configuration(lc)
     aglist = autoscale.get_all_groups(names=[cluster_name + "-ag"])
     if aglist:


### PR DESCRIPTION
It seems users of AWS say different things to the AWS documentation (typical crappy AWS documentation).  According to http://boto.cloudhackers.com/en/latest/ref/autoscale.html

```
spot_price (float) – The spot price you are bidding. Only applies if you are building an autoscaling group with spot instances.
```

After reading more at http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/US-SpotInstances.html it appears that the parameter is the actual bid price, _not_ the maximum price.  I.e. the price will be the bid price, no lower, no higher.

but the script says

```
        help="If specified, launch workers as spot instances with the given " +
             "maximum price (in dollars)")
```

and some blog https://aws.amazon.com/blogs/aws/ec2-spot-instance-updates-auto-scaling-and-cloudformation-integration-new-sample-app-1/ says

```
 When sufficient capacity is available at or below or your bid price, your group will expand up to the maximum size, and you’ll pay the market price (which could be lower than your bid).
```

Please can you confirm that when your bid price exceeds that which is necessary to buy an instance that the actual price paid is the price that is necessary, not the actual bid price. If so please accept my PR specific to the `--help` code, otherwise reject and remove the word "maximum".
